### PR TITLE
README.md更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,148 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Spring Boot template implementing Clean Architecture (Robert C. Martin). The project demonstrates proper layer separation with strict dependency rules enforced by ArchUnit tests.
+
+**Tech Stack**: Java 21, Spring Boot 3.5.5, jOOQ, MySQL 9.x, Thymeleaf, Spring Security, Flyway
+
+## Build & Run Commands
+
+```bash
+# Build the project
+./gradlew build
+
+# Run the application
+./gradlew bootRun
+
+# Generate jOOQ classes (run after database migrations)
+./gradlew generateJooq
+```
+
+**Application URL**: http://localhost:8080/samples
+**Login credentials**: test@example.com / password
+
+## Testing
+
+```bash
+# Unit tests only (excludes E2E)
+./gradlew test
+
+# Architecture compliance tests
+./gradlew archTest
+
+# E2E tests (Selenium)
+./gradlew e2eTest
+
+# Run all tests (CI pipeline)
+./gradlew ciTest
+
+# Run a single test
+./gradlew test --tests "ClassName.methodName"
+
+# Performance tests
+./gradlew test --tests "SamplePerformanceTest"
+```
+
+## Database Management
+
+```bash
+# Run Flyway migrations
+./gradlew flywayMigrate
+
+# View migration status
+./gradlew flywayInfo
+
+# Clean database (WARNING: destructive)
+./gradlew flywayClean
+```
+
+**Database connection**: jdbc:mysql://localhost:3306/template (root/root)
+
+## Code Quality & Reports
+
+```bash
+# Generate coverage report
+./gradlew jacocoTestReport
+
+# Generate all quality reports
+./gradlew qualityReport
+
+# Dependency analysis
+./gradlew dependencyReport
+
+# Code metrics
+./gradlew codeMetricsReport
+```
+
+## Architecture
+
+### Layer Structure
+
+```
+com.ngnmsn.template/
+├── domain/              # Core business logic (no dependencies)
+│   ├── model/          # Entities, value objects
+│   ├── service/        # Domain services
+│   ├── repository/     # Repository ports (interfaces)
+│   └── exception/      # Domain exceptions
+├── application/        # Use cases (depends only on domain)
+│   ├── service/        # Application services (orchestration)
+│   ├── command/        # Command objects
+│   ├── query/          # Query objects
+│   └── response/       # Response objects
+├── infrastructure/     # Technical implementation
+│   ├── repository/     # Repository adapters (jOOQ implementations)
+│   ├── config/         # Framework configuration
+│   └── adapter/        # External system adapters
+└── presentation/       # User interface layer
+    ├── web/            # Thymeleaf controllers
+    ├── api/            # REST API controllers
+    ├── form/           # Form objects
+    └── request/        # API request objects
+```
+
+### Dependency Rules (Enforced by ArchUnit)
+
+- **Domain**: Cannot depend on any other layer (pure Java only)
+- **Application**: Depends only on domain
+- **Infrastructure**: Can depend on domain and application
+- **Presentation**: Depends only on application
+
+**Critical**: Always follow the dependency inversion principle. Domain defines interfaces (ports), infrastructure provides implementations (adapters).
+
+### Naming Conventions
+
+- Domain services: `*DomainService`
+- Application services: `*ApplicationService`
+- Repository ports: `*RepositoryPort` (interface in domain)
+- Repository adapters: `*RepositoryAdapter` (implementation in infrastructure)
+- Controllers: `*Controller`
+- Exceptions: `*Exception`
+
+### Annotation Usage
+
+- Application services: `@Service` + `@Transactional`
+- Domain services: No annotations (pure Java)
+- Repository implementations: `@Repository`
+- Web controllers: `@Controller`
+- REST controllers: `@RestController`
+
+## Working with jOOQ
+
+After modifying database schema:
+1. Create Flyway migration in `src/main/resources/db/migration/`
+2. Run `./gradlew flywayMigrate`
+3. Regenerate jOOQ classes: `./gradlew generateJooq`
+
+Generated jOOQ code is excluded from test coverage.
+
+## Important Notes
+
+- ArchUnit tests validate architecture compliance - they will fail if dependency rules are violated
+- Domain layer must remain framework-agnostic (only `java.util.*`, `java.time.*` allowed)
+- Business logic belongs in domain services, not application services
+- Application services orchestrate use cases and manage transactions
+- Never put business logic in controllers or repository implementations

--- a/README.md
+++ b/README.md
@@ -1,231 +1,191 @@
-# Spring Boot Clean Architecture Template
+# Spring Boot クリーンアーキテクチャ テンプレート
 
-## 概要
-このプロジェクトはSpring Bootを使用したクリーンアーキテクチャのテンプレートです。
-真のクリーンアーキテクチャの原則に従い、保守性・テスタビリティ・拡張性に優れた設計を実現しています。
-
-## アーキテクチャ
-### レイヤー構成
-```
-┌─────────────────────────┐
-│ Presentation Layer      │ ← HTTP、UI、外部インターフェース
-├─────────────────────────┤
-│ Application Layer       │ ← ユースケース、オーケストレーション  
-├─────────────────────────┤
-│ Domain Layer           │ ← ビジネスルール、エンティティ（コア）
-├─────────────────────────┤
-│ Infrastructure Layer    │ ← DB、外部API、フレームワーク詳細
-└─────────────────────────┘
-```
-
-### 依存関係の方向
-- **Domain Layer**: 他のレイヤーに依存しない（最上位）
-- **Application Layer**: Domain Layerにのみ依存
-- **Infrastructure Layer**: Domain LayerとApplication Layerに依存
-- **Presentation Layer**: Application Layerにのみ依存
-
-### パッケージ構造
-```
-com.ngnmsn.template/
-├── domain/                 # ドメイン層
-│   ├── model/             # エンティティ・バリューオブジェクト
-│   ├── service/           # ドメインサービス
-│   ├── repository/        # リポジトリポート
-│   └── exception/         # ドメイン例外
-├── application/           # アプリケーション層
-│   ├── service/           # アプリケーションサービス
-│   ├── command/           # コマンドオブジェクト
-│   ├── query/             # クエリオブジェクト
-│   ├── response/          # レスポンスオブジェクト
-│   └── exception/         # アプリケーション例外
-├── infrastructure/       # インフラストラクチャ層
-│   ├── repository/        # リポジトリ実装
-│   ├── config/            # インフラ設定
-│   └── external/          # 外部システム連携
-└── presentation/         # プレゼンテーション層
-    ├── web/              # Webコントローラ
-    ├── api/              # REST APIコントローラ
-    ├── form/             # フォームオブジェクト
-    ├── request/          # APIリクエスト
-    ├── response/         # APIレスポンス
-    └── exception/        # プレゼンテーション例外処理
-```
+このプロジェクトは、Robert C. Martinのクリーンアーキテクチャを実装したSpring Bootテンプレートです。適切なレイヤー分離と、ArchUnitテストによる厳格な依存関係ルールの強制を実現しています。
 
 ## 技術スタック
-- **Java**: 21+
-- **Spring Boot**: 3.x
-- **Spring MVC**: Webレイヤー
-- **Spring Data JPA**: データアクセス
-- **jOOQ**: タイプセーフなSQL
-- **MySQL**: データベース
-- **Thymeleaf**: テンプレートエンジン
-- **JUnit 5**: テストフレームワーク
-- **ArchUnit**: アーキテクチャテスト
-- **Selenium**: E2Eテスト
 
-## セットアップ手順
+- **Java**: 21
+- **Spring Boot**: 3.5.5
+- **データベース**: MySQL 9.x
+- **O/Rマッパー**: jOOQ
+- **テンプレートエンジン**: Thymeleaf
+- **セキュリティ**: Spring Security
+- **マイグレーション**: Flyway
+- **ビルドツール**: Gradle
+
+## クイックスタート
 
 ### 前提条件
+
 - Java 21以上
 - MySQL 9.x
-- Docker（オプション）
+- Gradle
 
-### 環境構築方法
+### セットアップ
 
-#### MySQLの設定
-```shell
-# MySQLをインストール
-brew install mysql
-
-# mysqlを起動
-mysql.server start
-
-# rootユーザのパスワードを設定
-mysql -u root
-ALTER USER 'root'@'localhost' IDENTIFIED BY 'root';
-
-# rootユーザでログイン
-mysql -uroot -p
-
-# タイムゾーンを設定
-SET GLOBAL time_zone = '+09:00';
-SET time_zone = '+09:00';
-
-# データベース作成
-CREATE DATABASE template DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
-```
-
-#### リポジトリクローン・実行
 ```bash
-# プロジェクトのクローン
-git clone https://github.com/ngnmsn/spring-boot-template.git
-cd spring-boot-template
-
-# 依存関係の解決・ビルド
+# プロジェクトのビルド
 ./gradlew build
 
-# アプリケーション起動
-./gradlew bootRun
+# データベースマイグレーション
+./gradlew flywayMigrate
 
-# ブラウザで確認
-# http://localhost:8080/samples
+# jOOQクラスの生成
+./gradlew generateJooq
+
+# アプリケーションの起動
+./gradlew bootRun
 ```
 
+### アクセス情報
+
+- **アプリケーションURL**: http://localhost:8080/samples
+- **ログイン認証情報**:
+  - メールアドレス: `test@example.com`
+  - パスワード: `password`
+
+## アーキテクチャ
+
+### レイヤー構造
+
+```
+com.ngnmsn.template/
+├── domain/              # ドメイン層（コアビジネスロジック）
+│   ├── model/          # エンティティ、値オブジェクト
+│   ├── service/        # ドメインサービス
+│   ├── repository/     # リポジトリポート（インターフェース）
+│   └── exception/      # ドメイン例外
+├── application/        # アプリケーション層（ユースケース）
+│   ├── service/        # アプリケーションサービス（オーケストレーション）
+│   ├── command/        # コマンドオブジェクト
+│   ├── query/          # クエリオブジェクト
+│   └── response/       # レスポンスオブジェクト
+├── infrastructure/     # インフラストラクチャ層（技術的実装）
+│   ├── repository/     # リポジトリアダプター（jOOQ実装）
+│   ├── config/         # フレームワーク設定
+│   └── adapter/        # 外部システムアダプター
+└── presentation/       # プレゼンテーション層（ユーザーインターフェース）
+    ├── web/            # Thymeleafコントローラー
+    ├── api/            # REST APIコントローラー
+    ├── form/           # フォームオブジェクト
+    └── request/        # APIリクエストオブジェクト
+```
+
+### 依存関係ルール
+
+ArchUnitテストにより強制される依存関係ルール:
+
+- **Domain層**: 他のレイヤーに依存しない（純粋なJavaのみ）
+- **Application層**: Domain層のみに依存
+- **Infrastructure層**: DomainとApplication層に依存可能
+- **Presentation層**: Application層のみに依存
+
+### 命名規則
+
+- ドメインサービス: `*DomainService`
+- アプリケーションサービス: `*ApplicationService`
+- リポジトリポート: `*RepositoryPort`（domain層のインターフェース）
+- リポジトリアダプター: `*RepositoryAdapter`（infrastructure層の実装）
+- コントローラー: `*Controller`
+- 例外: `*Exception`
+
+### アノテーション使用方法
+
+- アプリケーションサービス: `@Service` + `@Transactional`
+- ドメインサービス: アノテーションなし（純粋なJava）
+- リポジトリ実装: `@Repository`
+- Webコントローラー: `@Controller`
+- REST APIコントローラー: `@RestController`
+
+## テスト
+
 ### テスト実行
+
 ```bash
-# 単体テスト
+# 単体テスト（E2Eテストを除く）
 ./gradlew test
 
-# アーキテクチャテスト
+# アーキテクチャ準拠テスト
 ./gradlew archTest
 
-# E2Eテスト
+# E2Eテスト（Selenium）
 ./gradlew e2eTest
 
-# 全テスト実行
+# 全テスト実行（CI用）
 ./gradlew ciTest
+
+# 特定のテストのみ実行
+./gradlew test --tests "ClassName.methodName"
 
 # パフォーマンステスト
 ./gradlew test --tests "SamplePerformanceTest"
 ```
 
-### 品質チェック・レポート生成
+### カバレッジレポート
+
 ```bash
-# コード品質レポート生成
+# カバレッジレポート生成
+./gradlew jacocoTestReport
+```
+
+レポートは `build/reports/jacoco/test/html/index.html` に生成されます。
+
+## データベース管理
+
+### データベース接続情報
+
+- **URL**: `jdbc:mysql://localhost:3306/template`
+- **ユーザー名**: `root`
+- **パスワード**: `root`
+
+### Flyway操作
+
+```bash
+# マイグレーション実行
+./gradlew flywayMigrate
+
+# マイグレーション状態確認
+./gradlew flywayInfo
+
+# データベースクリーン（警告：破壊的操作）
+./gradlew flywayClean
+```
+
+### jOOQクラス生成
+
+データベーススキーマを変更した後:
+
+1. `src/main/resources/db/migration/` にFlywayマイグレーションファイルを作成
+2. `./gradlew flywayMigrate` を実行
+3. `./gradlew generateJooq` でjOOQクラスを再生成
+
+## コード品質レポート
+
+```bash
+# カバレッジレポート生成
+./gradlew jacocoTestReport
+
+# 全品質レポート生成
 ./gradlew qualityReport
 
 # 依存関係分析
 ./gradlew dependencyReport
 
-# カバレッジレポート
-./gradlew jacocoTestReport
-
-# コードメトリクス
+# コードメトリクスレポート
 ./gradlew codeMetricsReport
 ```
 
-## 開発ガイドライン
+## 重要な設計原則
 
-### 新機能追加の手順
-1. **ドメインモデルの設計**: エンティティ・バリューオブジェクトを定義
-2. **リポジトリポートの定義**: ドメイン層にインターフェースを作成
-3. **ドメインサービス実装**: 複雑なビジネスロジックを実装
-4. **アプリケーションサービス実装**: ユースケースを実装
-5. **インフラストラクチャ実装**: リポジトリの具象実装を作成
-6. **プレゼンテーション実装**: コントローラ・フォームを作成
-7. **テスト作成**: 各層のテストを実装
-
-### コーディング規約
-- **命名規則**: 
-  - クラス名: PascalCase
-  - メソッド名: camelCase
-  - 定数: SCREAMING_SNAKE_CASE
-- **パッケージ命名**:
-  - ドメインサービス: `*DomainService`
-  - アプリケーションサービス: `*ApplicationService`
-  - リポジトリポート: `*RepositoryPort`
-  - リポジトリ実装: `*RepositoryAdapter`
-- **アノテーション**:
-  - アプリケーションサービス: `@Service` + `@Transactional`
-  - リポジトリ実装: `@Repository`
-  - コントローラ: `@Controller` or `@RestController`
-
-### アーキテクチャ制約
-以下の制約はArchUnitテストで自動検証されます：
-- ドメイン層は他の層に依存してはならない
-- アプリケーション層はドメイン層のみに依存する
-- インフラ層はプレゼンテーション層に依存してはならない
-- コントローラはアプリケーションサービスのみに依存する
-
-## デプロイメント
-
-### 本番環境設定
-```yaml
-# application-prod.yml
-spring:
-  datasource:
-    url: ${DATABASE_URL}
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: validate
-```
-
-### Docker実行
-```bash
-docker build -t spring-boot-template .
-docker run -p 8080:8080 spring-boot-template
-```
-
-## プロジェクトの特徴
-
-### 実現された成果
-- ✅ 真のクリーンアーキテクチャの実現
-- ✅ 依存関係逆転の原則の適用
-- ✅ レイヤー分離の徹底
-- ✅ テスタビリティの向上
-- ✅ 保守性・拡張性の確保
-- ✅ アーキテクチャテストによる継続的品質保証
-
-### アクセス・認証
-以下のURLからアプリケーションにアクセスできます：
-
-[http://localhost:8080/login](http://localhost:8080/login)
-
-| 項目     | 入力値              |
-|--------|------------------|
-| ログインID | test@example.com |
-| パスワード  | password         |
-
-## ドキュメント
-- [技術アーキテクチャドキュメント](./docs/ARCHITECTURE.md)
-- [開発者向けクイックスタート](./docs/QUICK_START.md)
-- [品質確認チェックリスト](./docs/QUALITY_CHECKLIST.md)
-- [ER図](./docs/er/ER.md)
+- **依存性逆転の原則**: Domain層がインターフェース（ポート）を定義し、Infrastructure層が実装（アダプター）を提供
+- **ビジネスロジックの配置**: ビジネスロジックはドメインサービスに、アプリケーションサービスにはユースケースのオーケストレーションのみ
+- **フレームワーク非依存**: Domain層はフレームワークに依存せず、`java.util.*`、`java.time.*`のみ使用可能
+- **アーキテクチャ検証**: ArchUnitテストにより依存関係ルール違反を検出
 
 ## ライセンス
+
 MIT License
 
-## 貢献
-プルリクエストを歓迎します。大きな変更の場合は、まずissueを作成してください。
+## 開発者向け情報
+
+詳細な開発ガイドは [CLAUDE.md](./CLAUDE.md) を参照してください。


### PR DESCRIPTION
This pull request introduces comprehensive documentation improvements for the project, focusing on clarifying the architecture, usage, and development guidelines. The main changes are the addition of a new English-language guide for Claude Code users and a major rewrite of the Japanese `README.md`, making both documents more detailed and consistent. These updates provide clear instructions for setup, testing, database management, code quality, and architectural principles.

**Documentation enhancements:**

* Added a new `CLAUDE.md` file in English, providing project overview, build/run/test commands, architecture details, naming conventions, annotation usage, jOOQ workflow, and important design notes for Claude Code users.
* Completely rewrote `README.md` in Japanese, expanding quickstart instructions, tech stack, architecture explanation, dependency rules, naming conventions, annotation usage, testing, database management, jOOQ usage, code quality reports, and design principles. Reference to `CLAUDE.md` for developer information was added.